### PR TITLE
Allow overriding Gemini's API version

### DIFF
--- a/audio/src/main/scala/com/alexitc/geminilive4s/GeminiService.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/GeminiService.scala
@@ -190,7 +190,8 @@ object GeminiService {
   def make(
       apiKey: String,
       promptSettings: GeminiPromptSettings,
-      functions: List[GeminiFunction]
+      functions: List[GeminiFunction],
+      customApiVersion: Option[GeminiCustomApi] = None
   ): fs2.Stream[IO, GeminiService] = {
     val wakeUpMessage =
       if (promptSettings.language.startsWith("es")) "Hola" else "Hello"
@@ -200,7 +201,8 @@ object GeminiService {
           apiKey,
           promptSettings,
           functions.map(_.declaration),
-          makeGeminiConfig
+          makeGeminiConfig,
+          customApiVersion
         )
       )
     } yield new GeminiService(gemini, functions, wakeUpMessage)

--- a/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiCustomApi.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiCustomApi.scala
@@ -1,0 +1,9 @@
+package com.alexitc.geminilive4s.models
+
+abstract class GeminiCustomApi(val string: String)
+
+object GeminiCustomApi {
+
+  // Required for native audio model
+  object V1Alpha extends GeminiCustomApi("v1alpha")
+}


### PR DESCRIPTION
This is required for some models like the native-audio ones.