### PR TITLE
Allow handling the voice activity manually

### DIFF
--- a/audio/src/main/scala/com/alexitc/geminilive4s/internal/GeminiIO.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/internal/GeminiIO.scala
@@ -40,6 +40,32 @@ private[geminilive4s] class GeminiIO(
     IO.fromCompletableFuture(f).void
   }
 
+  def sendActivityStart(): IO[Unit] = {
+    val f = IO {
+      session.sendRealtimeInput(
+        LiveSendRealtimeInputParameters
+          .builder()
+          .activityStart(ActivityStart.builder())
+          .build
+      )
+    }
+
+    IO.fromCompletableFuture(f).void
+  }
+
+  def sendActivityEnd(): IO[Unit] = {
+    val f = IO {
+      session.sendRealtimeInput(
+        LiveSendRealtimeInputParameters
+          .builder()
+          .activityStart(ActivityStart.builder())
+          .build
+      )
+    }
+
+    IO.fromCompletableFuture(f).void
+  }
+
   def sendMessage(message: String): IO[Unit] = {
     val f = IO {
       session.sendRealtimeInput(

--- a/audio/src/main/scala/com/alexitc/geminilive4s/internal/GeminiLiveConfigBuilder.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/internal/GeminiLiveConfigBuilder.scala
@@ -12,16 +12,15 @@ object GeminiLiveConfigBuilder {
     }
 
     val options = List(
-      transform(params.disableAutomaticActivityDetection)(builder =>
-        builder // TODO: Enable when the app supports handling this
-//        _.realtimeInputConfig(
-//          RealtimeInputConfig
-//            .builder()
-//            .automaticActivityDetection(
-//              AutomaticActivityDetection.builder().disabled(true).build()
-//            )
-//            .build()
-//        )
+      transform(params.disableAutomaticActivityDetection)(
+        _.realtimeInputConfig(
+          RealtimeInputConfig
+            .builder()
+            .automaticActivityDetection(
+              AutomaticActivityDetection.builder().disabled(true).build()
+            )
+            .build()
+        )
       ),
       transform(params.inputAudioTranscription)(
         _.inputAudioTranscription(AudioTranscriptionConfig.builder().build())

--- a/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiConfig.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiConfig.scala
@@ -10,7 +10,7 @@ case class GeminiConfig(
     // Required when using experimental models
     customApiVersion: Option[GeminiCustomApi] = None,
     // When enabled, Gemini waits for messages to confirm when the voice starts/stops
-    // NOTE: This is not implemented yet
+    // Requires v1alpha API
     disableAutomaticActivityDetection: Boolean = false,
     // When enabled, Gemini transcribes the input voice
     inputAudioTranscription: Boolean = false,

--- a/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiInputChunk.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiInputChunk.scala
@@ -1,0 +1,12 @@
+package com.alexitc.geminilive4s.models
+
+case class GeminiInputChunk(
+    chunk: Array[Byte],
+    // required when Gemini's automatic activity detection is disabled
+    activity: Option[GeminiInputChunk.ActivityEvent] = None
+)
+
+object GeminiInputChunk {
+  enum ActivityEvent:
+    case Start, End;
+}

--- a/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiOutputChunk.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiOutputChunk.scala
@@ -1,3 +1,7 @@
 package com.alexitc.geminilive4s.models
 
-case class GeminiOutputChunk(transcription: Transcription, chunk: Array[Byte])
+case class GeminiOutputChunk(
+    transcription: Transcription,
+    chunk: Array[Byte],
+    turnComplete: Boolean
+)


### PR DESCRIPTION
Gemini detects voice activity by default which is used mainly to detect interruptions, still, there are cases where this does not work nicely, now, we can disable that and tell Gemini when the voice activity starts/ends.