### PR TITLE
Fix bug with manual voice control

### DIFF
--- a/audio/src/main/scala/com/alexitc/geminilive4s/internal/GeminiIO.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/internal/GeminiIO.scala
@@ -58,7 +58,7 @@ private[geminilive4s] class GeminiIO(
       session.sendRealtimeInput(
         LiveSendRealtimeInputParameters
           .builder()
-          .activityStart(ActivityStart.builder())
+          .activityEnd(ActivityEnd.builder())
           .build
       )
     }


### PR DESCRIPTION
When sending ActivityEnd, we were actually sending ActivityStart, this causes Gemini to keep waiting for ActivityEnd indefinitely.