### PR TITLE
Make wakeUpMessage optional

### DIFF
--- a/audio/src/main/scala/com/alexitc/geminilive4s/GeminiService.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/GeminiService.scala
@@ -19,7 +19,7 @@ import scala.jdk.OptionConverters.*
 class GeminiService(
     gemini: GeminiIO,
     functions: List[GeminiFunction],
-    wakeUpMessage: String,
+    wakeUpMessage: Option[String],
     disableAutomaticActivityDetection: Boolean
 ) {
   import GeminiService.*
@@ -64,12 +64,15 @@ class GeminiService(
       // artificially start the conversation which causes gemini to speak
       wakeUpStream = fs2.Stream.exec {
         IO.whenA(geminiMustSpeakFirst) {
-          val send = if (disableAutomaticActivityDetection) {
-            gemini.sendActivityStart() >>
-              gemini.sendMessage(wakeUpMessage) >>
-              gemini.sendActivityEnd()
-          } else {
-            gemini.sendMessage(wakeUpMessage)
+          val send = (disableAutomaticActivityDetection, wakeUpMessage) match {
+            case (true, Some(message)) =>
+              gemini.sendActivityStart() >>
+                gemini.sendMessage(message) >>
+                gemini.sendActivityEnd()
+            case (false, Some(message)) =>
+              gemini.sendMessage(message)
+            case _ =>
+              IO.unit
           }
 
           IO.sleep(1.seconds) >>
@@ -207,9 +210,6 @@ object GeminiService {
       apiKey: String,
       config: GeminiConfig
   ): fs2.Stream[IO, GeminiService] = {
-    val wakeUpMessage =
-      if (config.language.string.startsWith("es")) "Hola"
-      else "Hello"
 
     for {
       gemini <- fs2.Stream.resource(
@@ -222,7 +222,7 @@ object GeminiService {
     } yield new GeminiService(
       gemini,
       config.functions,
-      wakeUpMessage,
+      config.wakeUpMessage,
       disableAutomaticActivityDetection =
         config.disableAutomaticActivityDetection
     )

--- a/audio/src/main/scala/com/alexitc/geminilive4s/GeminiService.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/GeminiService.scala
@@ -66,18 +66,20 @@ class GeminiService(
         IO.whenA(geminiMustSpeakFirst) {
           val send = (disableAutomaticActivityDetection, wakeUpMessage) match {
             case (true, Some(message)) =>
-              gemini.sendActivityStart() >>
+              IO.sleep(1.seconds) >>
+                IO.println("Sending wake up signal") >>
+                gemini.sendActivityStart() >>
                 gemini.sendMessage(message) >>
                 gemini.sendActivityEnd()
             case (false, Some(message)) =>
-              gemini.sendMessage(message)
+              IO.sleep(1.seconds) >>
+                IO.println("Sending wake up signal") >>
+                gemini.sendMessage(message)
             case _ =>
               IO.unit
           }
 
-          IO.sleep(1.seconds) >>
-            IO.println("Sending wake up signal") >>
-            send
+          send
         }
       }
 

--- a/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiConfig.scala
+++ b/audio/src/main/scala/com/alexitc/geminilive4s/models/GeminiConfig.scala
@@ -19,5 +19,8 @@ case class GeminiConfig(
     // Only a few models support this
     enableAffectiveDialog: Boolean = false,
     // Only a few models support this
-    proactivity: Boolean = false
+    proactivity: Boolean = false,
+    // Optional message sent automatically when the session starts
+    // Useful to wake up the model or trigger the first response
+    wakeUpMessage: Option[String] = None
 )


### PR DESCRIPTION
Makes *wakeUpMessage* optional in *GeminiConfig* to allow configurations where no initial message is required.